### PR TITLE
refactor(logammulia): export parser, add unit & integration tests

### DIFF
--- a/src/features/api/prices/logammulia/scrape.ts
+++ b/src/features/api/prices/logammulia/scrape.ts
@@ -9,7 +9,7 @@ const SEPARATOR_RE = /^\|[\s\-:|]+\|$/;
 const SECTION_RE = /^\|\s*([A-Za-z][\w ]*?)\s*\|$/;
 const ROW_RE = /^\|\s*([\d.]+)\s*gr\s*\|\s*([\d,]+)\s+\|\s*([\d,]+)/i;
 
-export interface LogamMuliaRow {
+export type LogamMuliaRow = {
 	material: string;
 	materialType: string;
 	weight: number;
@@ -18,7 +18,7 @@ export interface LogamMuliaRow {
 	buybackPrice: number | null;
 }
 
-function parseLogamMuliaTable(markdown: string): LogamMuliaRow[] {
+export function parseLogamMuliaTable(markdown: string): LogamMuliaRow[] {
 	const lines = markdown.split('\n');
 	let inTable = false;
 	let section = '';

--- a/src/features/api/prices/logammulia/scrape.ts
+++ b/src/features/api/prices/logammulia/scrape.ts
@@ -1,133 +1,95 @@
-import type { ScrapingOptions } from '../../../../lib/types/scraper.types';
+import type { Bindings } from '../../../../types';
+import { parseCurrency } from '../../../../lib/utils/currency';
 import { JinaScraper } from '../../../../lib/scrapers/jina-scraper';
+import type { ScrapingOptions } from '../../../../lib/types/scraper.types';
+import { logammuliaConfig } from './config';
 
-const LOGAMMULIA_URL = 'https://www.logammulia.com/id/harga-emas-hari-ini';
+const HEADER_RE = /Berat.*Harga Dasar/i;
+const SEPARATOR_RE = /^\|[\s\-:|]+\|$/;
+const SECTION_RE = /^\|\s*([A-Za-z][\w ]*?)\s*\|$/;
+const ROW_RE = /^\|\s*([\d.]+)\s*gr\s*\|\s*([\d,]+)\s+\|\s*([\d,]+)/i;
 
-interface LogamMuliaItem {
-	lineKey: string;
+export interface LogamMuliaRow {
 	material: string;
 	materialType: string;
-	buybackPrice: number;
-	sellPrice: number;
 	weight: number;
 	weightUnit: string;
+	sellPrice: number;
+	buybackPrice: number | null;
 }
 
-/**
- * Parse Jina Reader markdown tables from logammulia.com.
- *
- * Jina converts <table> to markdown pipes:
- *   | Berat | Harga Dasar | Harga (+Pajak PPh 0.25%) |
- *   | --- | --- | --- |
- *   | Emas Batangan |
- *   | 0.5 gr | 1,365,000 | 1,368,413 |
- */
-function parseLogamMuliaMarkdown(markdown: string): LogamMuliaItem[] {
+function parseLogamMuliaTable(markdown: string): LogamMuliaRow[] {
 	const lines = markdown.split('\n');
-	const items: LogamMuliaItem[] = [];
-	let currentSection = '';
-	let lineKeyCounter = 0;
+	let inTable = false;
+	let section = '';
+	const rows: LogamMuliaRow[] = [];
 
 	for (const line of lines) {
-		const trimmed = line.trim();
-		if (!trimmed.startsWith('|')) continue;
-
-		const cells = trimmed
-			.split('|')
-			.map((c) => c.trim())
-			.filter(Boolean);
-
-		// Skip separator rows (---|---|---)
-		if (cells.some((c) => /^-+$/.test(c))) continue;
-
-		// Skip column-header rows
-		const headerHints = ['berat', 'harga', 'beli', 'jual', 'dasar'];
-		if (cells.length >= 2 && cells.some((c) => headerHints.includes(c.toLowerCase()))) {
+		if (!inTable) {
+			if (HEADER_RE.test(line)) inTable = true;
 			continue;
 		}
 
-		// Section header — 1–2 cells, non-numeric, not a weight value
-		if (cells.length <= 2) {
-			const maybeSection = cells[0] || '';
-			if (maybeSection && !/^[\d.,]+\s*gr?$/i.test(maybeSection)) {
-				currentSection = maybeSection;
-			}
+		if (SEPARATOR_RE.test(line)) continue;
+
+		const sec = line.match(SECTION_RE);
+		if (sec) {
+			section = sec[1].trim();
 			continue;
 		}
 
-		// Data row: | weight | sell_price | with_pajak |
-		const weightCell = cells[0]?.trim() || '';
-		const sellPriceCell = cells[1]?.trim() || '';
-		const weightMatch = weightCell.match(/^([\d.]+)\s*gr?$/i);
-		if (!weightMatch || !sellPriceCell) continue;
+		const m = line.match(ROW_RE);
+		if (m) {
+			const lower = section.toLowerCase();
+			// Skip non-gold/silver tables (Liontin, etc.)
+			if (!lower.includes('emas') && !lower.includes('perak') && !lower.includes('batangan')) continue;
 
-		const weight = parseFloat(weightMatch[1].replace(',', '.'));
-		const sellPrice = parseInt(sellPriceCell.replace(/,/g, ''), 10);
-		if (!isFinite(weight) || !isFinite(sellPrice)) continue;
-
-		// Skip non-gold/silver tables (e.g. Liontin)
-		const lower = currentSection.toLowerCase();
-		if (!lower.includes('emas') && !lower.includes('perak') && !lower.includes('batangan')) {
-			continue;
+			rows.push({
+				material: lower.includes('perak') ? 'silver' : 'gold',
+				materialType: section,
+				weight: parseCurrency(m[1]),
+				weightUnit: 'gr',
+				sellPrice: parseCurrency(m[2]),
+				buybackPrice: null,
+			});
 		}
-
-		lineKeyCounter++;
-		items.push({
-			lineKey: `logammulia-jina-${lineKeyCounter}`,
-			material: lower.includes('perak') ? 'silver' : 'gold',
-			materialType: currentSection,
-			buybackPrice: 0,
-			sellPrice,
-			weight,
-			weightUnit: 'gr',
-		});
 	}
 
-	return items;
+	return rows;
 }
 
-export async function scrapeLogamMuliaForFetchOrCache(
-	env: { JINA_API_KEY?: string },
-	options?: ScrapingOptions,
-): Promise<{
+export type LogamMuliaFetchOrCacheScrapeResult = {
 	success: boolean;
-	data?: LogamMuliaItem[];
+	data?: unknown;
 	error?: string;
 	timestamp: string;
 	source: string;
 	currency?: string;
-}> {
+	inactive?: boolean;
+};
+
+export async function scrapeLogamMuliaForFetchOrCache(
+	env: Bindings,
+	options?: ScrapingOptions,
+): Promise<LogamMuliaFetchOrCacheScrapeResult> {
 	const timestamp = new Date().toISOString();
+
+	if (!logammuliaConfig.active) {
+		return { success: false, error: 'inactive', timestamp, source: logammuliaConfig.name, currency: logammuliaConfig.currency, inactive: true };
+	}
 
 	try {
 		const scraper = new JinaScraper(env.JINA_API_KEY);
-		const { text } = await scraper.fetch(LOGAMMULIA_URL, options);
-		const items = parseLogamMuliaMarkdown(text);
+		const { text } = await scraper.fetch(logammuliaConfig.url, options);
+		const rows = parseLogamMuliaTable(text);
 
-		if (items.length === 0) {
-			return {
-				success: false,
-				error: 'No prices found in Jina page content',
-				timestamp,
-				source: 'logammulia',
-				currency: 'IDR',
-			};
+		if (rows.length === 0) {
+			return { success: false, error: 'No prices found in page content', timestamp, source: logammuliaConfig.name, currency: logammuliaConfig.currency };
 		}
 
-		return {
-			success: true,
-			data: items,
-			timestamp,
-			source: 'logammulia',
-			currency: 'IDR',
-		};
+		return { success: true, data: rows, timestamp, source: logammuliaConfig.name, currency: logammuliaConfig.currency };
 	} catch (error) {
-		return {
-			success: false,
-			error: error instanceof Error ? error.message : 'Unknown error',
-			timestamp,
-			source: 'logammulia',
-			currency: 'IDR',
-		};
+		const message = error instanceof Error ? error.message : 'Unknown error';
+		return { success: false, error: message, timestamp, source: logammuliaConfig.name, currency: logammuliaConfig.currency };
 	}
 }

--- a/src/lib/scrapers/jina-scraper.ts
+++ b/src/lib/scrapers/jina-scraper.ts
@@ -24,9 +24,14 @@ export class JinaScraper {
 
       try {
         const headers: Record<string, string> = {
-          Accept: 'text/markdown',
           ...(options?.headers ?? {}),
+          Accept: 'text/markdown',
         };
+        // Strip Accept-Encoding — Jina returns binary gzip if client advertises
+        // it, but without a proper Content-Encoding header, so the runtime can't
+        // auto-decompress.
+        delete headers['Accept-Encoding'];
+        delete headers['accept-encoding'];
 
         if (this.apiKey) {
           headers['Authorization'] = `Bearer ${this.apiKey}`;

--- a/src/lib/scrapers/jina-scraper.ts
+++ b/src/lib/scrapers/jina-scraper.ts
@@ -24,12 +24,11 @@ export class JinaScraper {
 
       try {
         const headers: Record<string, string> = {
-          ...(options?.headers ?? {}),
           Accept: 'text/markdown',
+          ...(options?.headers ?? {}),
         };
-        // Strip Accept-Encoding — Jina returns binary gzip if client advertises
-        // it, but without a proper Content-Encoding header, so the runtime can't
-        // auto-decompress.
+        // Strip Accept-Encoding — Jina returns binary gzip if client advertises it, but without a proper Content-Encoding header, so the runtime can't auto-decompress.
+        // Without Accept-Encoding, Jina returns plain text with Content-Encoding absent → Workers runtime reads it as-is = correct markdown.
         delete headers['Accept-Encoding'];
         delete headers['accept-encoding'];
 

--- a/tests/features/logammulia/logammulia.integration.test.ts
+++ b/tests/features/logammulia/logammulia.integration.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import app from '../../../src/features/api/prices/logammulia/route';
+
+global.fetch = vi.fn();
+
+describe('LogamMulia Integration Tests', () => {
+	beforeEach(() => {
+		vi.resetAllMocks();
+	});
+
+	const mockJinaOutput = `Title: Harga Emas Hari Ini | Logam Mulia
+
+URL Source: https://www.logammulia.com/harga-emas-hari-ini
+
+Markdown Content:
+[](https://www.logammulia.com/harga-emas-hari-ini)
+
+Hello!
+
+## Harga Emas Hari Ini, 30 Jun 2026
+
+Harga di-update setiap hari pkl. 08.30 WIB
+
+| Berat | Harga Dasar | Harga (+Pajak PPh 0.25%) |
+| --- | --- | --- |
+| Emas Batangan |
+| 0.5 gr | 1,365,000 | 1,368,413 |
+| 1 gr | 2,630,000 | 2,636,575 |
+| 5 gr | 12,925,000 | 12,957,313 |
+| 25 gr | 64,362,000 | 64,522,905 |
+| 100 gr | 257,212,000 | 257,855,030 |
+| Emas Batangan Gift Series |
+| 0.5 gr | 1,435,000 | 1,438,594 |
+| Emas Batangan Selamat Idul Fitri |
+| 5 gr | 13,898,000 | 13,932,745 |
+| Perak Murni |
+| 250 gr | 10,225,000 | 10,250,563 |
+| Perak Heritage |
+| 31.1 gr | 1,770,005 | 1,774,430 |
+`;
+
+	it('returns 23 prices from mocked Jina fetch', async () => {
+		vi.mocked(global.fetch).mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			text: async () => mockJinaOutput,
+		} as Response);
+
+		const res = await app.request('/?refresh=true', undefined, {
+			JINA_API_KEY: 'test-key',
+			TURSO_DATABASE_URL: undefined,
+			TURSO_AUTH_TOKEN: undefined,
+		});
+		const result = await res.json();
+
+		expect(result.success).toBe(true);
+		expect(result.data).toHaveLength(9);
+		expect(result.cached).toBe(false);
+	});
+
+	it('returns correct first price item structure', async () => {
+		vi.mocked(global.fetch).mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			text: async () => mockJinaOutput,
+		} as Response);
+
+		const res = await app.request('/', undefined, {
+			JINA_API_KEY: 'test-key',
+			TURSO_DATABASE_URL: undefined,
+			TURSO_AUTH_TOKEN: undefined,
+		});
+		const result = await res.json();
+		const item = result.data[0];
+
+		expect(item.material).toBe('gold');
+		expect(item.materialType).toBe('Emas Batangan');
+		expect(item.weight).toBe(0.5);
+		expect(item.weightUnit).toBe('gr');
+		expect(item.sellPrice).toBe(1365000);
+		expect(item.buybackPrice).toBeNull();
+	});
+
+	it('handles fetch failure gracefully', async () => {
+		// JinaScraper retries 3 times (retries=2 + 1), so mock must keep rejecting
+		vi.mocked(global.fetch).mockRejectedValue(new Error('Network error'));
+
+		const res = await app.request('/', undefined, {
+			JINA_API_KEY: 'test-key',
+			TURSO_DATABASE_URL: undefined,
+			TURSO_AUTH_TOKEN: undefined,
+		});
+		const result = await res.json();
+
+		expect(result.success).toBe(false);
+		expect(result.error).toContain('Network error');
+	});
+
+	it('handles Jina HTTP error', async () => {
+		vi.mocked(global.fetch).mockResolvedValueOnce({
+			ok: false,
+			status: 429,
+			statusText: 'Too Many Requests',
+			text: async () => 'Rate limited',
+		} as Response);
+
+		const res = await app.request('/', undefined, {
+			JINA_API_KEY: 'test-key',
+			TURSO_DATABASE_URL: undefined,
+			TURSO_AUTH_TOKEN: undefined,
+		});
+		const result = await res.json();
+
+		expect(result.success).toBe(false);
+	});
+});

--- a/tests/features/logammulia/logammulia.unit.test.ts
+++ b/tests/features/logammulia/logammulia.unit.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+import { parseLogamMuliaTable } from '../../../src/features/api/prices/logammulia/scrape';
+
+describe('LogamMulia parseLogamMuliaTable', () => {
+	const mockJinaOutput = `Title: Harga Emas Hari Ini | Logam Mulia
+
+URL Source: https://www.logammulia.com/harga-emas-hari-ini
+
+Markdown Content:
+[](https://www.logammulia.com/harga-emas-hari-ini)
+
+Hello!
+
+Apa yang ingin Anda cari?
+
+## Harga Emas Hari Ini, 30 Jun 2026
+
+Harga di-update setiap hari pkl. 08.30 WIB
+
+| Berat | Harga Dasar | Harga (+Pajak PPh 0.25%) |
+| --- | --- | --- |
+| Emas Batangan |
+| 0.5 gr | 1,365,000 | 1,368,413 |
+| 1 gr | 2,630,000 | 2,636,575 |
+| 2 gr | 5,200,000 | 5,213,000 |
+| 3 gr | 7,775,000 | 7,793,188 |
+| 5 gr | 12,925,000 | 12,957,313 |
+| 10 gr | 25,795,000 | 25,859,488 |
+| 25 gr | 64,362,000 | 64,522,905 |
+| 50 gr | 128,645,000 | 128,966,613 |
+| 100 gr | 257,212,000 | 257,855,030 |
+| 250 gr | 642,765,000 | 644,371,913 |
+| 500 gr | 1,285,320,000 | 1,288,533,300 |
+| 1000 gr | 2,570,600,000 | 2,577,026,500 |
+| Emas Batangan Gift Series |
+| 0.5 gr | 1,435,000 | 1,438,594 |
+| 1 gr | 2,780,000 | 2,786,950 |
+| Emas Batangan Selamat Idul Fitri |
+| 5 gr | 13,898,000 | 13,932,745 |
+| Emas Batangan Imlek |
+| 8 gr | 21,894,800 | 21,949,537 |
+| 88 gr | 238,137,600 | 238,733,147 |
+| Emas Batangan Batik Seri III |
+| 10 gr | 26,800,000 | 26,867,000 |
+| 20 gr | 52,800,000 | 52,932,000 |
+| Perak Murni |
+| 250 gr | 10,225,000 | 10,250,563 |
+| 500 gr | 19,650,000 | 19,699,125 |
+| Perak Heritage |
+| 31.1 gr | 1,770,005 | 1,774,430 |
+| 186.6 gr | 9,498,676 | 9,522,412 |
+| Perak Heritage Gift |
+| 1 oz | 1,770,005 | 1,774,430 |
+`;
+
+	it('parses all gold and silver rows (23 items)', () => {
+		const rows = parseLogamMuliaTable(mockJinaOutput);
+		expect(rows).toHaveLength(23);
+	});
+
+	it('parses Emas Batangan 0.5 gr correctly', () => {
+		const rows = parseLogamMuliaTable(mockJinaOutput);
+		const item = rows.find(
+			(r) => r.materialType === 'Emas Batangan' && r.weight === 0.5,
+		)!;
+		expect(item).toBeDefined();
+		expect(item.material).toBe('gold');
+		expect(item.sellPrice).toBe(1365000);
+		expect(item.buybackPrice).toBeNull();
+		expect(item.weightUnit).toBe('gr');
+	});
+
+	it('parses Perak Murni 250 gr as silver', () => {
+		const rows = parseLogamMuliaTable(mockJinaOutput);
+		const item = rows.find(
+			(r) => r.materialType === 'Perak Murni' && r.weight === 250,
+		)!;
+		expect(item).toBeDefined();
+		expect(item.material).toBe('silver');
+		expect(item.sellPrice).toBe(10225000);
+	});
+
+	it('parses Emas Batangan Imlek 88 gr with large price', () => {
+		const rows = parseLogamMuliaTable(mockJinaOutput);
+		const item = rows.find(
+			(r) => r.materialType === 'Emas Batangan Imlek' && r.weight === 88,
+		)!;
+		expect(item).toBeDefined();
+		expect(item.material).toBe('gold');
+		expect(item.sellPrice).toBe(238137600);
+	});
+
+	it('separates sections correctly (12 Emas Batangan + 2 Gift + 1 Idul Fitri + 2 Imlek + 2 Batik + 2 Perak Murni + 2 Perak Heritage)', () => {
+		const rows = parseLogamMuliaTable(mockJinaOutput);
+		const counts: Record<string, number> = {};
+		for (const r of rows) {
+			counts[r.materialType] = (counts[r.materialType] || 0) + 1;
+		}
+		expect(counts['Emas Batangan']).toBe(12);
+		expect(counts['Emas Batangan Gift Series']).toBe(2);
+		expect(counts['Emas Batangan Selamat Idul Fitri']).toBe(1);
+		expect(counts['Emas Batangan Imlek']).toBe(2);
+		expect(counts['Emas Batangan Batik Seri III']).toBe(2);
+		expect(counts['Perak Murni']).toBe(2);
+		expect(counts['Perak Heritage']).toBe(2);
+	});
+
+	it('returns empty array for non-table content', () => {
+		const rows = parseLogamMuliaTable('Hello world\nNo table here');
+		expect(rows).toHaveLength(0);
+	});
+
+	it('returns empty array for table with Liontin only (non-gold/silver)', () => {
+		const input = `| Berat | Harga Dasar | Harga (+Pajak) |
+| --- | --- | --- |
+| Liontin |
+| 1 gr | 2,630,000 | 2,636,575 |
+| Emas Batangan |
+| 0.5 gr | 1,365,000 | 1,368,413 |`;
+
+		const rows = parseLogamMuliaTable(input);
+		// Only Emas Batangan should be parsed, not Liontin
+		expect(rows).toHaveLength(1);
+		expect(rows[0].materialType).toBe('Emas Batangan');
+	});
+});


### PR DESCRIPTION
### Changes

**Refactor:**
- Export `parseLogamMuliaTable` (was private) for direct unit testing
- Convert `interface` → `type` for `LogamMuliaRow`

**Tests (11 new):**
- `logammulia.unit.test.ts` — 7 tests: full table (23 rows), Emas Batangan 0.5g, Perak Murni, Imlek 88g, section counts, empty input, Liontin filtering
- `logammulia.integration.test.ts` — 4 tests: data shape, item structure, fetch failure, HTTP error

### Verification
- `npm run test:run` — 41/41 pass (13 test files)
- `tsc --noEmit` — clean