### PR TITLE
fix(pegadaian): correct postProcess for allGrafik API shape + add date freshness check

### DIFF
--- a/src/features/api/prices/pegadaian/config.ts
+++ b/src/features/api/prices/pegadaian/config.ts
@@ -1,5 +1,39 @@
 import type { JsonApiConfig } from '../../../../lib';
 
+function normalizeDate(lastUpdate: string): string {
+	return lastUpdate.replace(' ', 'T') + '.000Z';
+}
+
+export function getLatestPrice(
+	series: Record<string, unknown> | undefined,
+): string {
+	const fluk = series?.jsonFluktuasi as Record<string, unknown> | undefined;
+	const list = fluk?.priceList as Array<Record<string, unknown>> | undefined;
+	if (!Array.isArray(list) || list.length === 0) return '';
+	// API is newest-first: index 0 = today's price
+	const latest = list[0];
+	// Only return price if lastUpdate matches series updateDate (fresh today)
+	const updateDate = series?.updateDate as string | undefined;
+	const lastUpdate = latest.lastUpdate as string | undefined;
+	if (!updateDate || !lastUpdate) return String(latest.harga ?? '');
+	if (normalizeDate(lastUpdate) !== updateDate) return '';
+	return String(latest.harga ?? '');
+}
+
+export function pegadaianPostProcess(raw: Record<string, unknown>): Record<string, string> {
+	const outerData = (raw?.data as Record<string, unknown>) ?? {};
+	const allGrafik = outerData.allGrafik as Array<Record<string, unknown>> | undefined;
+	if (!Array.isArray(allGrafik)) return { hargaJual: '', hargaBeli: '' };
+
+	const sellSeries = allGrafik.find((g) => g.tipe === 'jual');
+	const buySeries = allGrafik.find((g) => g.tipe === 'beli');
+
+	return {
+		hargaJual: getLatestPrice(sellSeries),
+		hargaBeli: getLatestPrice(buySeries),
+	};
+}
+
 export const pegadaianConfig: JsonApiConfig = {
 	name: 'pegadaian',
 	displayName: 'Pegadaian',
@@ -11,37 +45,7 @@ export const pegadaianConfig: JsonApiConfig = {
 	method: 'GET',
 	currency: 'IDR',
 	active: true,
-	postProcess: (raw) => {
-		const data = raw as Record<string, unknown>;
-		const outerData = (data?.data as Record<string, unknown>) ?? {};
-		const allGrafik = outerData.allGrafik as Array<Record<string, unknown>> | undefined;
-		if (!Array.isArray(allGrafik)) return { hargaJual: '', hargaBeli: '' };
-
-		// allGrafik alternates sell/buy per interval: [jual7, beli7, jual30, beli30, ...]
-		const sellSeries = allGrafik.find((g) => g.tipe === 'jual');
-		const buySeries = allGrafik.find((g) => g.tipe === 'beli');
-
-		const getLatestPrice = (series: Record<string, unknown> | undefined): string => {
-			const fluk = series?.jsonFluktuasi as Record<string, unknown> | undefined;
-			const list = fluk?.priceList as Array<Record<string, unknown>> | undefined;
-			if (!Array.isArray(list) || list.length === 0) return '';
-			// API is newest-first: index 0 = today's price
-			const latest = list[0];
-			// Only return price if lastUpdate matches series updateDate (fresh today)
-			const updateDate = series?.updateDate as string | undefined;
-			const lastUpdate = latest.lastUpdate as string | undefined;
-			if (!updateDate || !lastUpdate) return String(latest.harga ?? '');
-			// Convert "2026-06-30 00:00:00" → "2026-06-30T00:00:00.000Z"
-			const normalizedLast = lastUpdate.replace(' ', 'T') + '.000Z';
-			if (normalizedLast !== updateDate) return '';
-			return String(latest.harga ?? '');
-		};
-
-		return {
-			hargaJual: getLatestPrice(sellSeries),
-			hargaBeli: getLatestPrice(buySeries),
-		};
-	},
+	postProcess: (raw) => pegadaianPostProcess(raw),
 	selector: [
 		{
 			sellPrice: 'hargaJual',

--- a/src/features/api/prices/pegadaian/config.ts
+++ b/src/features/api/prices/pegadaian/config.ts
@@ -13,14 +13,33 @@ export const pegadaianConfig: JsonApiConfig = {
 	active: true,
 	postProcess: (raw) => {
 		const data = raw as Record<string, unknown>;
-		const inner = (data?.data as Record<string, unknown>) ?? {};
-		const priceList = inner.priceList;
-		const lastItem = Array.isArray(priceList) && priceList.length > 0
-			? priceList[priceList.length - 1] as Record<string, unknown>
-			: {};
+		const outerData = (data?.data as Record<string, unknown>) ?? {};
+		const allGrafik = outerData.allGrafik as Array<Record<string, unknown>> | undefined;
+		if (!Array.isArray(allGrafik)) return { hargaJual: '', hargaBeli: '' };
+
+		// allGrafik alternates sell/buy per interval: [jual7, beli7, jual30, beli30, ...]
+		const sellSeries = allGrafik.find((g) => g.tipe === 'jual');
+		const buySeries = allGrafik.find((g) => g.tipe === 'beli');
+
+		const getLatestPrice = (series: Record<string, unknown> | undefined): string => {
+			const fluk = series?.jsonFluktuasi as Record<string, unknown> | undefined;
+			const list = fluk?.priceList as Array<Record<string, unknown>> | undefined;
+			if (!Array.isArray(list) || list.length === 0) return '';
+			// API is newest-first: index 0 = today's price
+			const latest = list[0];
+			// Only return price if lastUpdate matches series updateDate (fresh today)
+			const updateDate = series?.updateDate as string | undefined;
+			const lastUpdate = latest.lastUpdate as string | undefined;
+			if (!updateDate || !lastUpdate) return String(latest.harga ?? '');
+			// Convert "2026-06-30 00:00:00" → "2026-06-30T00:00:00.000Z"
+			const normalizedLast = lastUpdate.replace(' ', 'T') + '.000Z';
+			if (normalizedLast !== updateDate) return '';
+			return String(latest.harga ?? '');
+		};
+
 		return {
-			hargaJual: String(lastItem.hargaJual ?? ''),
-			hargaBeli: String(lastItem.hargaBeli ?? ''),
+			hargaJual: getLatestPrice(sellSeries),
+			hargaBeli: getLatestPrice(buySeries),
 		};
 	},
 	selector: [

--- a/tests/features/pegadaian/pegadaian.unit.test.ts
+++ b/tests/features/pegadaian/pegadaian.unit.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import { getLatestPrice, pegadaianPostProcess } from '../../../src/features/api/prices/pegadaian/config';
+
+describe('pegadaian getLatestPrice', () => {
+	const sellSeries = {
+		tipe: 'jual',
+		updateDate: '2026-06-30T00:00:00.000Z',
+		jsonFluktuasi: {
+			priceList: [
+				{ harga: '25240', lastUpdate: '2026-06-30 00:00:00' },
+				{ harga: '25450', lastUpdate: '2026-06-29 00:00:00' },
+				{ harga: '25550', lastUpdate: '2026-06-28 00:00:00' },
+			],
+		},
+	};
+
+	it('returns latest price when lastUpdate matches updateDate', () => {
+		expect(getLatestPrice(sellSeries)).toBe('25240');
+	});
+
+	it('returns empty string when lastUpdate mismatches updateDate (stale data)', () => {
+		const staleSeries = {
+			...sellSeries,
+			// Only older entries, no match for today's updateDate
+			jsonFluktuasi: {
+				priceList: [
+					{ harga: '25450', lastUpdate: '2026-06-29 00:00:00' },
+				],
+			},
+		};
+		expect(getLatestPrice(staleSeries)).toBe('');
+	});
+
+	it('returns price if dates missing (fallback)', () => {
+		const noDates = {
+			tipe: 'jual',
+			jsonFluktuasi: {
+				priceList: [
+					{ harga: '99999' },
+				],
+			},
+		};
+		expect(getLatestPrice(noDates)).toBe('99999');
+	});
+
+	it('returns empty string for empty priceList', () => {
+		const empty = {
+			tipe: 'jual',
+			updateDate: '2026-06-30T00:00:00.000Z',
+			jsonFluktuasi: { priceList: [] },
+		};
+		expect(getLatestPrice(empty)).toBe('');
+	});
+
+	it('returns empty string for undefined series', () => {
+		expect(getLatestPrice(undefined)).toBe('');
+	});
+
+	it('returns empty string for series without jsonFluktuasi', () => {
+		expect(getLatestPrice({} as Record<string, unknown>)).toBe('');
+	});
+
+	it('picks first (newest) entry, not last', () => {
+		const series = {
+			tipe: 'jual',
+			updateDate: '2026-06-30T00:00:00.000Z',
+			jsonFluktuasi: {
+				priceList: [
+					{ harga: '100', lastUpdate: '2026-06-30 00:00:00' },
+					{ harga: '200', lastUpdate: '2026-06-29 00:00:00' },
+					{ harga: '300', lastUpdate: '2026-06-28 00:00:00' },
+				],
+			},
+		};
+		expect(getLatestPrice(series)).toBe('100');
+	});
+});
+
+describe('pegadaian pegadaianPostProcess', () => {
+	const validPayload = {
+		responseCode: '2000000100',
+		data: {
+			allGrafik: [
+				{
+					tipe: 'jual',
+					updateDate: '2026-06-30T00:00:00.000Z',
+					jsonFluktuasi: {
+						priceList: [{ harga: '25240', lastUpdate: '2026-06-30 00:00:00' }],
+					},
+				},
+				{
+					tipe: 'beli',
+					updateDate: '2026-06-30T00:00:00.000Z',
+					jsonFluktuasi: {
+						priceList: [{ harga: '23970', lastUpdate: '2026-06-30 00:00:00' }],
+					},
+				},
+			],
+		},
+	};
+
+	it('returns hargaJual and hargaBeli from valid payload', () => {
+		const result = pegadaianPostProcess(validPayload);
+		expect(result).toEqual({ hargaJual: '25240', hargaBeli: '23970' });
+	});
+
+	it('returns empty strings when allGrafik missing', () => {
+		const result = pegadaianPostProcess({ data: {} });
+		expect(result).toEqual({ hargaJual: '', hargaBeli: '' });
+	});
+
+	it('returns empty strings when data missing', () => {
+		const result = pegadaianPostProcess({});
+		expect(result).toEqual({ hargaJual: '', hargaBeli: '' });
+	});
+});


### PR DESCRIPTION
### Bug
Pegadaian `sellPrice` and `buybackPrice` returned 0 because `postProcess` looked for `data.priceList[{ hargaJual, hargaBeli }]` but real API returns `data.allGrafik[].jsonFluktuasi.priceList[{ harga }]`.

### Changes

**Refactor (`config.ts`):**
- Extract `getLatestPrice()` and `pegadaianPostProcess()` as exported functions
- `pegadaianPostProcess` finds `jual`/ `beli` series in `allGrafik` and extracts latest price
- `getLatestPrice` picks `list[0]` (API is newest-first, not oldest-first) and validates `lastUpdate === updateDate` before returning price
- If dates mismatch (stale data), returns `''` → effective 0

**Tests (10 new):**
- `getLatestPrice`: matching date, stale date, missing dates fallback, empty list, undefined series, missing jsonFluktuasi, verifies picks first not last
- `pegadaianPostProcess`: valid payload, missing allGrafik, missing data

### Verification
- `npm run test:run` — 40/40 pass (12 test files)
- Live endpoint: `sellPrice=25240, buybackPrice=23970`