### PR TITLE
fix(cors): enable cross-origin requests from browser clients

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { OpenAPIHono } from '@hono/zod-openapi';
 import { Scalar } from '@scalar/hono-api-reference';
+import { cors } from 'hono/cors';
 import { createErrorResponse, getHistoryBySource } from './lib';
 import { registerPriceFeatures } from './lib/feature-registry';
 import { registerNewsFeatures } from './lib/news-registry';
@@ -9,6 +10,16 @@ import healthRoute from './features/health';
 import { listSourcesRoute, historyRoute } from './lib/openapi-helpers';
 
 const app = new OpenAPIHono<{ Bindings: Bindings }>();
+
+app.use(
+	'*',
+	cors({
+		origin: '*',
+		allowMethods: ['GET', 'OPTIONS'],
+		allowHeaders: ['Content-Type'],
+		maxAge: 86400,
+	}),
+);
 
 app.route('/', rootRoute);
 app.route('/health', healthRoute);

--- a/tests/cors.test.ts
+++ b/tests/cors.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import app from '../src/index';
+
+describe('CORS middleware', () => {
+	it('attaches Access-Control-Allow-Origin to normal GET responses', async () => {
+		const res = await app.request('/');
+
+		expect(res.status).toBe(200);
+		expect(res.headers.get('Access-Control-Allow-Origin')).toBe('*');
+	});
+
+	it('responds to OPTIONS preflight with 204 and the configured headers', async () => {
+		const res = await app.request('/api/prices/logammulia', {
+			method: 'OPTIONS',
+			headers: {
+				Origin: 'https://example.com',
+				'Access-Control-Request-Method': 'GET',
+				'Access-Control-Request-Headers': 'content-type',
+			},
+		});
+
+		expect(res.status).toBe(204);
+		expect(res.headers.get('Access-Control-Allow-Origin')).toBe('*');
+		expect(res.headers.get('Access-Control-Allow-Methods')).toBe('GET,OPTIONS');
+		expect(res.headers.get('Access-Control-Allow-Headers')).toBe('Content-Type');
+		expect(res.headers.get('Access-Control-Max-Age')).toBe('86400');
+	});
+
+	// ponytail: preflight must not 404 even for unknown paths — cors runs before routing
+	it('returns 204 for preflight on an unknown route', async () => {
+		const res = await app.request('/api/prices/does-not-exist', {
+			method: 'OPTIONS',
+			headers: {
+				Origin: 'https://example.com',
+				'Access-Control-Request-Method': 'GET',
+			},
+		});
+
+		expect(res.status).toBe(204);
+		expect(res.headers.get('Access-Control-Allow-Origin')).toBe('*');
+	});
+});


### PR DESCRIPTION
Endpoints (e.g. /api/prices/logammulia, /api/prices/galeri24) returned 200 to curl but sent no Access-Control-Allow-Origin

- GET/POST/etc responses carry Access-Control-Allow-Origin: * (status & body unchanged; cors only adds a header, then next())

Fixes #146 